### PR TITLE
Introducing MQ connectivity with related unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.amqphub.quarkus</groupId>
       <artifactId>quarkus-qpid-jms</artifactId>
-      <version>0.29.0</version>
+      <version>0.30.0</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,16 +52,17 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.amqphub.quarkus</groupId>
+      <artifactId>quarkus-qpid-jms</artifactId>
+      <version>0.29.0</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/src/main/java/ibm/gse/orderms/infra/jms/JMSQueueWriter.java
+++ b/src/main/java/ibm/gse/orderms/infra/jms/JMSQueueWriter.java
@@ -1,0 +1,37 @@
+package ibm.gse.orderms.infra.jms;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.Session;
+
+/**
+ A bean that sends generic serializable payload to JMS queue using qpid APIs
+ */
+
+@ApplicationScoped
+public class JMSQueueWriter<T> {
+
+    @Inject
+    private ConnectionFactory connectionFactory;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final Logger logger = LoggerFactory.getLogger(JMSQueueWriter.class);
+
+    public void sendMessage(final T message, final String queueName) throws Exception {
+        try (JMSContext context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE)) {
+            context.createProducer().send(
+                    context.createQueue(queueName), mapper.writeValueAsString(message));
+            logger.info("Message sent on queue " + queueName);
+        } catch (Exception e) {
+            logger.error("MANAGE ME", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,16 @@
 app.version=1.0.0
-mp.openapi.extensions.smallrye.info.title=Order management service API
-mp.openapi.extensions.smallrye.info.version=1.0.0
-mp.openapi.extensions.smallrye.info.description=The Shipping Order manager service
-mp.openapi.extensions.smallrye.info.termsOfService=Your terms here...
-mp.openapi.extensions.smallrye.info.contact.email=techsupport@example.com
-mp.openapi.extensions.smallrye.info.contact.name=API Support
-mp.openapi.extensions.smallrye.info.contact.url=http://exampleurl.com/contact
-mp.openapi.extensions.smallrye.info.license.name=Apache 2.0
-mp.openapi.extensions.smallrye.info.license.url=https://www.apache.org/licenses/LICENSE-2.0.html
+
+# Configures the Qpid JMS properties.
+quarkus.qpid-jms.url=amqp://localhost:5672
+quarkus.qpid-jms.username=app
+quarkus.qpid-jms.password=passw0rd
+
+# No authentication for test
+%test.quarkus.qpid-jms.username=
+%test.quarkus.qpid-jms.password=
+
+quarkus.log.level=INFO
+quarkus.amqp.devservices.enabled=false
 
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=INFO
@@ -16,8 +19,6 @@ quarkus.native.resources.includes=orders.json
 quarkus.swagger-ui.always-include=true
 quarkus.http.cors=true
 quarkus.http.port=8080
-
-
 
 #################################
 # Source to Image to openshift 

--- a/src/test/ibm/gse/orderms/PriceTest.java
+++ b/src/test/ibm/gse/orderms/PriceTest.java
@@ -12,7 +12,6 @@ import javax.inject.Inject;
 import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 public class PriceTest {

--- a/src/test/ibm/gse/orderms/PriceTest.java
+++ b/src/test/ibm/gse/orderms/PriceTest.java
@@ -1,0 +1,44 @@
+package ibm.gse.orderms;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ibm.gse.orderms.domain.model.order.ShippingOrder;
+import ibm.gse.orderms.infra.jms.JMSQueueWriter;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class PriceTest {
+
+    private static final Logger log = Logger.getLogger(PriceTest.class);
+
+    @Inject
+    private JMSQueueWriter<ShippingOrder> jmsQueueWriter;
+
+    @Test
+    public void testLastPrice() throws Exception {
+        assertDoesNotThrow(() ->
+            jmsQueueWriter.sendMessage(getOrderFromTestFile(), "DEV.QUEUE.1")
+        );
+    }
+
+    public ShippingOrder getOrderFromTestFile() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        InputStream is = getClass().getClassLoader().getResourceAsStream("order.json");
+        if (is == null)
+            throw new IllegalAccessError("file not found for order json");
+        try {
+            return mapper.readValue(is, mapper.getTypeFactory().constructType(ShippingOrder.class));
+        } catch (Exception e) {
+            log.error("Error reading resource file", e);
+            throw e;
+        }
+    }
+}

--- a/src/test/resources/order.json
+++ b/src/test/resources/order.json
@@ -1,0 +1,14 @@
+{ "orderID" : "OrderTest",
+  "productID" : "TestP01",
+  "customerID" : "TestC01",
+  "voyageID": "TestV01",
+  "containerID": "TestFR01",
+  "quantity": 10,
+  "pickupDate": "2020/03/30",
+  "expectedDeliveryDate": "2020/05/30",
+  "pickupAddress": {"street": "1 main street", "city" : "Amsterdam",
+    "country": "Neederland", "state": "AA", "zipcode": "92000"},
+  "destinationAddress": {"street": "migliaccio street", "city" : "girifalco",
+    "country": "ITALY", "state": "CALABRIA", "zipcode": "88024"},
+  "status" : "pending"
+}


### PR DESCRIPTION
Introduced classes, configurations and unit tests to connect with qpid (quarkus version) library to IBM MQ queue with AMQP. With this commit, the integration with MQ is placed only in the class ShippingOrderResource.java, and thus it only sends messages on the queue. The name of the queue is externalized via environment variable. Next steps would be

1. Implement queue wathcer component, that catches other types of events to control
2. Implement rollback logic
3. Define orchestration logic